### PR TITLE
Fix OLED funcitonality

### DIFF
--- a/keyboards/crkbd/keymaps/greyhatmiddleman_trackball_left/keymap.c
+++ b/keyboards/crkbd/keymaps/greyhatmiddleman_trackball_left/keymap.c
@@ -119,7 +119,7 @@ void pointing_device_task() {
 
 #ifdef OLED_DRIVER_ENABLE
 oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-  if (is_master) {
+  if (is_keyboard_master()) {
     return OLED_ROTATION_180;  // flips the display 180 degrees if offhand
   }
   return rotation;
@@ -205,7 +205,7 @@ void oled_render_logo(void) {
 }
 
 void oled_task_user(void) {
-    if (is_master) {
+    if (is_keyboard_master()) {
         oled_render_logo();
         //oled_render_layer_state();
         //oled_render_keylog();

--- a/keyboards/crkbd/keymaps/greyhatmiddleman_trackball_right/keymap.c
+++ b/keyboards/crkbd/keymaps/greyhatmiddleman_trackball_right/keymap.c
@@ -119,7 +119,7 @@ void pointing_device_task() {
 
 #ifdef OLED_DRIVER_ENABLE
 oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-  if (is_master) {
+  if (is_keyboard_master()) {
     return OLED_ROTATION_180;  // flips the display 180 degrees if offhand
   }
   return rotation;
@@ -205,7 +205,7 @@ void oled_render_logo(void) {
 }
 
 void oled_task_user(void) {
-    if (is_master) {
+    if (is_keyboard_master()) {
         oled_render_logo();
         //oled_render_layer_state();
         //oled_render_keylog();


### PR DESCRIPTION
Fixed the missing function to get OLED started

## Description

I enabled the OLED support and updated this function to get it compiled and running on my Corne LP with 2 OLEDs

tested using Elite C and wired off the OLED screen connection

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* OLED can be safely enabled

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
